### PR TITLE
New ExtraMediaQuery for Tablets

### DIFF
--- a/src/main/scala/com/fortysevendeg/scala/android/macroid/DefaultTag.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/macroid/DefaultTag.scala
@@ -1,0 +1,8 @@
+package com.fortysevendeg.scala.android.macroid
+
+import macroid.LogTag
+
+trait Tag {
+  implicit val logTag = LogTag("ApiDemos")
+}
+object Tag extends Tag

--- a/src/main/scala/com/fortysevendeg/scala/android/macroid/ExtraMediaQueries.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/macroid/ExtraMediaQueries.scala
@@ -1,0 +1,11 @@
+package com.fortysevendeg.scala.android.macroid
+
+import macroid.AppContext
+import macroid.FullDsl._
+
+trait DevicesQueries {
+  def tablet(implicit ctx: AppContext) = widerThan(720 dp)
+  def landscapeTablet(implicit ctx: AppContext) = widerThan(720 dp) & landscape
+  def portraitTablet(implicit ctx: AppContext) = widerThan(720 dp) & portrait
+}
+object DevicesQueries extends DevicesQueries

--- a/src/main/scala/com/fortysevendeg/scala/android/ui/circularreveal/Styles.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/ui/circularreveal/Styles.scala
@@ -8,6 +8,7 @@ import com.fortysevendeg.scala.android.macroid.TextTweaks._
 import com.fortysevendeg.scala.android.macroid.LinearLayoutTweaks._
 import com.fortysevendeg.scala.android.macroid.ViewTweaks._
 import com.fortysevendeg.scala.android.ui.components.CircleButtonTweaks._
+import macroid.FullDsl._
 
 object Styles {
 

--- a/src/main/scala/com/fortysevendeg/scala/android/ui/main/MainActivity.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/ui/main/MainActivity.scala
@@ -2,21 +2,20 @@ package com.fortysevendeg.scala.android.ui.main
 
 import android.os.{Build, Bundle}
 import android.support.v7.app.ActionBarActivity
-import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.{GridLayoutManager, LinearLayoutManager}
 import com.fortysevendeg.scala.android.R
 import com.fortysevendeg.scala.android.macroid.ExtraActions._
 import com.fortysevendeg.scala.android.ui.circularreveal.CircularRevealActivity
 import com.fortysevendeg.scala.android.ui.ripplebackground.RippleBackgroundActivity
 import com.fortysevendeg.scala.android.ui.textstyles.TextStylesActivity
 import macroid.Contexts
-
+import macroid.FullDsl._
+import com.fortysevendeg.scala.android.macroid.DevicesQueries._
 
 class MainActivity
     extends ActionBarActivity
     with Contexts[ActionBarActivity]
     with Layout {
-
-  val layoutManager = new LinearLayoutManager(this)
 
   override def onCreate(savedInstanceState: Bundle) = {
     super.onCreate(savedInstanceState)
@@ -36,6 +35,12 @@ class MainActivity
         }
       }
     })
+
+    val layoutManager =
+      landscapeTablet ?
+          new GridLayoutManager(this, 4) |
+          tablet ?
+              new GridLayoutManager(this, 3) | new LinearLayoutManager(this)
 
     recyclerView.map(view => {
       view.setLayoutManager(layoutManager)

--- a/src/main/scala/com/fortysevendeg/scala/android/ui/main/Styles.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/ui/main/Styles.scala
@@ -2,12 +2,11 @@ package com.fortysevendeg.scala.android.ui.main
 
 import android.graphics.Color
 import android.view.Gravity
-import com.fortysevendeg.scala.android.R
+import macroid.FullDsl._
 import com.fortysevendeg.scala.android.macroid.LinearLayoutTweaks._
-import com.fortysevendeg.scala.android.macroid.RecyclerViewTweaks._
 import com.fortysevendeg.scala.android.macroid.TextTweaks._
 import com.fortysevendeg.scala.android.macroid.ViewTweaks._
-import com.fortysevendeg.scala.android.macroid.CardViewTweaks._
+import macroid.AppContext
 
 object Styles {
 
@@ -17,14 +16,14 @@ object Styles {
 
   val cardStyle = vMatchWidth
 
-  val itemStyle = llVertical + vMatchWidth + vPaddings(40)
+  def itemStyle(implicit appContext: AppContext) = llVertical + vMatchWidth + vPaddings(12 dp)
 
-  val itemTopStyle = llHorizontal + vContentSizeMatchWidth(100) + llGravity(Gravity.CENTER_VERTICAL)
+  def itemTopStyle(implicit appContext: AppContext) = llHorizontal + vContentSizeMatchWidth(72 dp) + llGravity(Gravity.CENTER_VERTICAL)
 
   val titleStyle = llWrapWeightHorizontal + tvSize(18) + tvColor(Color.BLACK)
 
   val descriptionStyle = tvSize(14) + tvNormalLight + tvColor(Color.GRAY) + tvMaxLines(2)
 
-  val apiStyle = tvSize(10) + tvItalicLight + tvColor(Color.WHITE) + vPaddings(12)
+  def apiStyle(implicit appContext: AppContext) = tvSize(10) + tvItalicLight + tvColor(Color.WHITE) + vPaddings(8 dp)
 
 }

--- a/src/main/scala/com/fortysevendeg/scala/android/ui/ripplebackground/Styles.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/ui/ripplebackground/Styles.scala
@@ -4,6 +4,7 @@ import android.view.Gravity
 import android.widget.LinearLayout
 import com.fortysevendeg.scala.android.macroid.LinearLayoutTweaks._
 import com.fortysevendeg.scala.android.macroid.ViewTweaks._
+import macroid.AppContext
 import macroid.FullDsl._
 
 object Styles {
@@ -16,10 +17,6 @@ object Styles {
 
   val circlesContentStyle = vMatchParent + llGravity(Gravity.CENTER_HORIZONTAL)
 
-  // TODO We need use dp, px or ps in this object. Compiler say "value dp is not a member of Int"
-  // It's possible that we need implicits parameters
-  //val circleStyle = lp[LinearLayout](60 dp, 60 dp)
-
-  val circleStyle = lp[LinearLayout](100, 100) + vMargins(20)
+  def circleStyle(implicit appContext: AppContext) = lp[LinearLayout](64 dp, 64 dp) + vMargins(8 dp)
 
 }

--- a/src/main/scala/com/fortysevendeg/scala/android/ui/textstyles/Styles.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/ui/textstyles/Styles.scala
@@ -1,19 +1,16 @@
 package com.fortysevendeg.scala.android.ui.textstyles
 
-import android.graphics.Color
-import android.view.Gravity
-import com.fortysevendeg.scala.android.R
+import macroid.FullDsl._
 import com.fortysevendeg.scala.android.macroid.LinearLayoutTweaks._
-import com.fortysevendeg.scala.android.macroid.RecyclerViewTweaks._
 import com.fortysevendeg.scala.android.macroid.TextTweaks._
 import com.fortysevendeg.scala.android.macroid.ViewTweaks._
-import com.fortysevendeg.scala.android.macroid.CardViewTweaks._
+import macroid.AppContext
 
 object Styles {
 
   val contentStyle = llVertical
 
-  val scrollStyle = llVertical + vPaddings(10)
+  def scrollStyle(implicit appContext: AppContext) = llVertical + vPaddings(8 dp)
 
   val textLargeStyle = tvSize(24)
 

--- a/src/main/scala/com/fortysevendeg/scala/android/utils/Implicits.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/utils/Implicits.scala
@@ -1,9 +1,0 @@
-package com.fortysevendeg.scala.android.utils
-
-import macroid.LogTag
-
-object Tag {
-
-  implicit val logTag = LogTag("ApiDemos")
-
-}


### PR DESCRIPTION
I have added a new ExtraMediaQuery for help us to define when a device is a tablet or not. We can use it when we need different implementations in our code for different devices

For example, in main list I use several columns in tablet but only one column in cell phones

I have also fixed a previous problem that we couldn't use "dp" in Style file. We have add the AppContext implicit. Currently I have to add the implicit in every method. Is possible that will we look for a better way for this?

@raulraja can you please review? Thanks

@FPerezP Speak now or shut up forever! :-p
