### PR TITLE
Using 47deg Macroid Contribution for Multi-Method Listeners

### DIFF
--- a/project/Libraries.scala
+++ b/project/Libraries.scala
@@ -64,7 +64,7 @@ object Libraries {
     def macroid(module: String = "") =
       "org.macroid" %% s"macroid${if(!module.isEmpty) s"-$module" else ""}" % Versions.macroidV
 
-    lazy val macroidRoot = macroid()
+    lazy val macroidRoot = "org.macroid" %% "macroid" % "2.0.1"
     lazy val macroidAkkaFragments = macroid("akka-fragments")
     lazy val macroidExtras = "com.fortysevendeg" %% "macroid-extras" % Versions.macroidExtras
   }


### PR DESCRIPTION
# DO NOT MERGE!!!

This PR shows a use of case regarding to `SeekBar` control on the Scala Android project to manage several methods asociated to the `SeekBar.OnSeekBarChangeListener`.

To accomplish it I've developed a new macro within the macroid project and then I've published the artifact in the 47deg bintray repo for testing purposes.

@javipacheco @franciscodr @fedefernandez @raulraja it looks good to you? Also, I need you as beta-testers of this contribution in order to send an official PR to the macroid project repo.

Thanks!